### PR TITLE
Add package manifest for governance toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+node_modules/
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
+
 WORKDIR /app
-COPY app.py .
-RUN pip install flask requests
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV OPA_URL=http://opa:8181
+
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,152 @@
-# OPA
-OPA Rego
+# OPA Governance Toolkit
+
+This project provides a reference implementation of an automated governance layer that
+wraps a development platform with [Open Policy Agent](https://www.openpolicyagent.org/) (OPA)
+policies. The toolkit demonstrates how to:
+
+- Enforce HIPAA log redaction controls so protected health information (PHI) never reaches logs or API responses.
+- Validate every generated Terraform, Helm or general Kubernetes YAML manifest before it is merged or applied.
+- Apply compliance guardrails that ensure security groups are never opened to `0.0.0.0/0`,
+  container images are cosign signed, and pods always run as non-root.
+- Automatically adopt new governance rules as soon as they are published by a compliance team,
+  removing the need for manual policy rollouts.
+
+## Architecture Overview
+
+```
+┌────────────────┐        ┌──────────────────────────┐        ┌──────────────────┐
+│ Developer Tool │ -----> │ Governance Flask API     │ -----> │ OPA Server       │
+│ (CI/CD, IDE)   │        │ - PolicyManager pushes   │        │ - Evaluates Rego │
+│                │ <----- │   and refreshes policies │ <----- │   policies       │
+└────────────────┘        └──────────────────────────┘        └──────────────────┘
+                                   ▲
+                                   │ dynamic policy feed
+                                   ▼
+                           `policy_feed/*.rego`
+```
+
+* `app.py` exposes REST endpoints that delegate decisions to OPA.
+* `PolicyManager` automatically publishes all Rego policies from `policies/base` and
+  watches `policy_feed` for new rules from the compliance team.
+* Each Rego module contributes to the `gatekeeper` and `logsecurity` packages which the
+  API queries at run time.
+
+## Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `POST /logs/check` | Validates that a log entry contains no PHI and does not include debug logging statements. |
+| `POST /gatekeeper/validate` | Validates Terraform, Helm, Kubernetes YAML and container image metadata before a merge/apply. |
+| `POST /policies/reload` | Forces an immediate republish of all policies. |
+| `GET /policies/status` | Returns metadata about the currently loaded policies and the last sync times. |
+
+### Log evaluation payload
+
+```json
+{
+  "log": {
+    "language": "python",
+    "message": "Patient SSN 123-45-6789 saved",
+    "fields": {
+      "patient_name": "Jane Doe"
+    }
+  }
+}
+```
+
+The `logsecurity` policy blocks common debugging statements and a rich set of PHI indicators
+(field names and regular expressions for SSNs, MRNs, and medical emails).
+
+### Gatekeeper payload
+
+```json
+{
+  "artifacts": [
+    {
+      "type": "terraform",
+      "name": "networking",
+      "content": {
+        "security_groups": [
+          {
+            "name": "web-sg",
+            "rules": [
+              {"name": "ingress", "cidr": "0.0.0.0/0"}
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "type": "kubernetes",
+      "name": "api-pod",
+      "content": {
+        "pods": [
+          {
+            "name": "api",
+            "containers": [
+              {"name": "api", "securityContext": {"runAsNonRoot": false}}
+            ]
+          }
+        ]
+      },
+      "metadata": {
+        "cms_guidance_required": true,
+        "annotations": {}
+      }
+    },
+    {
+      "type": "container_image",
+      "name": "backend",
+      "content": {"image": "registry/my/backend:1.2.3", "cosign_verified": true}
+    }
+  ]
+}
+```
+
+OPA returns detailed violation messages for any artifacts that are not compliant. The example above would
+produce three violations: an open security group, a pod that runs as root, and a CMS/FDA guidance annotation
+violation supplied via the dynamic `policy_feed/cms_fda_guidance.rego` rule.
+
+## Automated policy updates
+
+The governance layer polls the `policy_feed` directory (or any directory supplied through the
+`DYNAMIC_POLICY_DIR` environment variable). When a new `.rego` file is added, modified or removed the
+`PolicyManager` publishes the change to OPA without needing to redeploy the API container. The supplied
+`cms_fda_guidance.rego` file demonstrates how compliance teams can inject additional guardrails at run time.
+
+## Running locally with Docker Compose
+
+```bash
+docker-compose up --build
+```
+
+The compose file starts both the OPA server and the governance API. Policies from `policies/base` are published at
+startup, and any additional rules copied into `policy_feed` are detected automatically.
+
+## Development
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+FLASK_ENV=development python app.py
+```
+
+Unit tests (if added) can import the Flask application without requiring a running OPA instance because
+policy publishing errors are logged but do not abort start-up.
+
+## Repository layout
+
+```
+.
+├── app.py                   # Flask API with policy synchronisation
+├── policies
+│   └── base                 # Default governance policies
+│       ├── gatekeeper.rego
+│       └── log_security.rego
+├── policy_feed              # Dynamic policies sourced from compliance
+│   └── cms_fda_guidance.rego
+├── docker-compose.yml       # Sample environment with OPA and the API
+├── Dockerfile
+└── requirements.txt
+```

--- a/app.py
+++ b/app.py
@@ -1,29 +1,251 @@
-from flask import Flask, request, jsonify
+import atexit
+import hashlib
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
 import requests
+from flask import Flask, jsonify, request
+
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+logger = logging.getLogger(__name__)
+
+OPA_URL = os.getenv("OPA_URL", "http://opa:8181").rstrip("/")
+BASE_POLICY_DIR = Path(os.getenv("BASE_POLICY_DIR", "policies/base"))
+DYNAMIC_POLICY_DIR = Path(os.getenv("DYNAMIC_POLICY_DIR", "policy_feed"))
+POLICY_POLL_INTERVAL = int(os.getenv("POLICY_POLL_INTERVAL", "30"))
+AUTO_START_POLICY_MANAGER = os.getenv("AUTO_START_POLICY_MANAGER", "true").lower() not in {
+    "false",
+    "0",
+    "no",
+}
+
+LOG_POLICY_PATH = "logsecurity/deny"
+GATEKEEPER_POLICY_PATH = "gatekeeper/violations"
+
+
+def opa_query(path: str, payload: Dict) -> Dict:
+    """Send a data query to OPA and return the parsed result."""
+    url = f"{OPA_URL}/v1/data/{path}"
+    logger.debug("Querying OPA at %s", url)
+
+    try:
+        response = requests.post(url, json={"input": payload}, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        logger.exception("OPA query failed: %s", exc)
+        raise
+
+
+class PolicyManager:
+    """Synchronises local Rego policies with a running OPA instance."""
+
+    def __init__(
+        self,
+        opa_url: str,
+        base_dir: Path,
+        dynamic_dir: Optional[Path] = None,
+        poll_interval: int = 30,
+    ) -> None:
+        self.opa_url = opa_url.rstrip("/")
+        self.base_dir = base_dir
+        self.dynamic_dir = dynamic_dir
+        self.poll_interval = poll_interval
+        self.session = requests.Session()
+        self._loaded: Dict[str, Dict] = {}
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.status: Dict[str, Optional[str]] = {
+            "last_full_sync": None,
+            "policy_count": 0,
+            "dynamic_policy_count": 0,
+            "last_dynamic_sync": None,
+        }
+
+    def start(self) -> None:
+        """Load policies immediately and start background polling."""
+        logger.info("Initialising policy manager")
+        self.force_reload()
+
+        if self.dynamic_dir and self.poll_interval > 0:
+            self._thread = threading.Thread(target=self._watch_loop, daemon=True)
+            self._thread.start()
+            logger.info(
+                "Started background policy watcher for %s (interval=%ss)",
+                self.dynamic_dir,
+                self.poll_interval,
+            )
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    def force_reload(self) -> None:
+        """Reload all policies, ignoring cached hashes."""
+        with self._lock:
+            self._loaded.clear()
+            self._sync_directory(self.base_dir, prefix="base")
+            if self.dynamic_dir:
+                self._sync_directory(self.dynamic_dir, prefix="dynamic")
+            self.status.update(
+                {
+                    "last_full_sync": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    "policy_count": sum(1 for k in self._loaded if k.startswith("base:")),
+                    "dynamic_policy_count": sum(1 for k in self._loaded if k.startswith("dynamic:")),
+                }
+            )
+
+    def _watch_loop(self) -> None:
+        logger.debug("Entering policy watch loop")
+        while not self._stop_event.wait(self.poll_interval):
+            with self._lock:
+                self._sync_directory(self.dynamic_dir, prefix="dynamic")
+                dynamic_count = sum(1 for key in self._loaded if key.startswith("dynamic:"))
+                self.status["dynamic_policy_count"] = dynamic_count
+                self.status["last_dynamic_sync"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    def _sync_directory(self, directory: Optional[Path], prefix: str) -> int:
+        if not directory or not directory.exists():
+            logger.debug("Policy directory %s does not exist", directory)
+            return 0
+
+        logger.info("Synchronising %s policies from %s", prefix, directory)
+        seen_ids = set()
+        count = 0
+
+        for file_path in sorted(directory.rglob("*.rego")):
+            policy_id = self._policy_id(prefix, directory, file_path)
+            seen_ids.add(policy_id)
+            count += 1
+            self._publish_policy(policy_id, file_path)
+
+        # Remove policies that no longer exist on disk
+        existing_ids = {key for key in self._loaded if key.startswith(f"{prefix}:")}
+        for stale_id in existing_ids - seen_ids:
+            self._delete_policy(stale_id)
+
+        return count
+
+    def _policy_id(self, prefix: str, root: Path, file_path: Path) -> str:
+        relative = file_path.relative_to(root).with_suffix("")
+        normalized = str(relative).replace(os.sep, "_")
+        return f"{prefix}:{normalized}"
+
+    def _publish_policy(self, policy_id: str, file_path: Path) -> None:
+        content = file_path.read_text()
+        policy_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        cached = self._loaded.get(policy_id)
+
+        if cached and cached["hash"] == policy_hash:
+            logger.debug("Policy %s unchanged", policy_id)
+            return
+
+        opa_endpoint = f"{self.opa_url}/v1/policies/{policy_id}"
+        logger.info("Publishing policy %s to %s", policy_id, opa_endpoint)
+        try:
+            response = self.session.put(
+                opa_endpoint,
+                data=content,
+                headers={"Content-Type": "text/plain"},
+                timeout=10,
+            )
+            response.raise_for_status()
+            self._loaded[policy_id] = {"hash": policy_hash, "path": str(file_path)}
+        except requests.RequestException as exc:
+            logger.error("Failed to publish policy %s: %s", policy_id, exc)
+            self.status["last_error"] = str(exc)
+
+    def _delete_policy(self, policy_id: str) -> None:
+        opa_endpoint = f"{self.opa_url}/v1/policies/{policy_id}"
+        logger.info("Deleting policy %s", policy_id)
+        try:
+            response = self.session.delete(opa_endpoint, timeout=10)
+            if response.status_code in (200, 204, 404):
+                self._loaded.pop(policy_id, None)
+            else:
+                response.raise_for_status()
+        except requests.RequestException as exc:
+            logger.error("Failed to delete policy %s: %s", policy_id, exc)
+            self.status["last_error"] = str(exc)
+
 
 app = Flask(__name__)
-OPA_URL = "http://opa:8181/v1/data/logfilter/deny"
+policy_manager = PolicyManager(
+    opa_url=OPA_URL,
+    base_dir=BASE_POLICY_DIR,
+    dynamic_dir=DYNAMIC_POLICY_DIR,
+    poll_interval=POLICY_POLL_INTERVAL,
+)
+if AUTO_START_POLICY_MANAGER:
+    policy_manager.start()
+    atexit.register(policy_manager.stop)
+
 
 @app.route("/")
 def home():
-    return "OPA Log Filter API is running."
+    return "OPA Governance API is running."
+
+
+def _extract_log_payload(data: Dict) -> Dict:
+    if "log" in data:
+        return data["log"]
+    return data
+
 
 @app.route("/check-log", methods=["POST"])
+@app.route("/logs/check", methods=["POST"])
 def check_log():
-    log_entry = request.json
-    opa_response = requests.post(OPA_URL, json={"input": log_entry})
-    result = opa_response.json()
+    payload = request.get_json(force=True)
+    log_entry = _extract_log_payload(payload)
 
-    if "result" in result and result["result"]:
-        return jsonify({
-            "allowed": False,
-            "reasons": result["result"]
-        }), 403
-    else:
-        return jsonify({
-            "allowed": True,
-            "message": "Log entry is allowed"
-        }), 200
+    try:
+        opa_result = opa_query(LOG_POLICY_PATH, {"log": log_entry})
+    except requests.RequestException:
+        return jsonify({"allowed": False, "error": "OPA backend unavailable"}), 503
+    deny_reasons = opa_result.get("result", [])
+
+    if deny_reasons:
+        return jsonify({"allowed": False, "reasons": deny_reasons}), 403
+
+    return jsonify({"allowed": True, "message": "Log entry is compliant"})
+
+
+@app.route("/gatekeeper/validate", methods=["POST"])
+def gatekeeper_validate():
+    payload = request.get_json(force=True)
+    artifacts = payload.get("artifacts", [])
+
+    try:
+        opa_result = opa_query(GATEKEEPER_POLICY_PATH, {"artifacts": artifacts})
+    except requests.RequestException:
+        return jsonify({"allowed": False, "error": "OPA backend unavailable"}), 503
+    violations = opa_result.get("result", [])
+
+    return jsonify({
+        "allowed": len(violations) == 0,
+        "violations": violations,
+    }), (200 if not violations else 422)
+
+
+@app.route("/policies/reload", methods=["POST"])
+def reload_policies():
+    policy_manager.force_reload()
+    return jsonify({"status": "reloaded", "metadata": policy_manager.status})
+
+
+@app.route("/policies/status", methods=["GET"])
+def policies_status():
+    return jsonify(policy_manager.status)
+
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    try:
+        app.run(host="0.0.0.0", port=5000)
+    finally:
+        policy_manager.stop()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,22 @@
-version: '3'
+version: "3.9"
+
 services:
   opa:
     image: openpolicyagent/opa:latest
+    command: ["run", "--server", "--log-level=debug"]
     ports:
       - "8181:8181"
-    command: ["run", "--server"]
-    volumes:
-      - ./opa_flask_package/logfilter.rego:/logfilter.rego
-      - ./opa_flask_package:/policies
-    working_dir: /policies
 
-  flask-api:
-    build: ./opa_flask_package
+  governance-api:
+    build: .
+    environment:
+      - OPA_URL=http://opa:8181
+      - BASE_POLICY_DIR=/app/policies/base
+      - DYNAMIC_POLICY_DIR=/app/policy_feed
+      - POLICY_POLL_INTERVAL=10
+    volumes:
+      - ./policies:/app/policies:ro
+      - ./policy_feed:/app/policy_feed
     ports:
       - "5000:5000"
     depends_on:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "opa-governance-toolkit",
+  "version": "1.0.0",
+  "description": "Governance layer for HIPAA redaction, Gatekeeper validation, and automated OPA policy management.",
+  "private": true,
+  "scripts": {
+    "start": "python app.py",
+    "test": "python -m pytest"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/policies/base/gatekeeper.rego
+++ b/policies/base/gatekeeper.rego
@@ -1,0 +1,78 @@
+package gatekeeper
+
+# Primary entry point that the API queries to receive all policy violations.
+violations[v] {
+    artifact := input.artifacts[_]
+    lower(artifact.type) == "terraform"
+    v := terraform_security_group_open(artifact)
+}
+
+violations[v] {
+    artifact := input.artifacts[_]
+    lower(artifact.type) == "kubernetes"
+    v := kubernetes_runs_as_root(artifact)
+}
+
+violations[v] {
+    artifact := input.artifacts[_]
+    lower(artifact.type) == "helm"
+    v := kubernetes_runs_as_root(artifact)
+}
+
+violations[v] {
+    artifact := input.artifacts[_]
+    lower(artifact.type) == "container_image"
+    v := image_not_cosign_signed(artifact)
+}
+
+# Terraform compliance: security groups must not allow 0.0.0.0/0 ingress or egress.
+terraform_security_group_open(artifact) = violation {
+    sg := artifact.content.security_groups[_]
+    rule := sg.rules[_]
+    cidr := rule.cidr
+    cidr == "0.0.0.0/0"
+    violation := {
+        "artifact": artifact.name,
+        "type": "terraform",
+        "rule": "sg-no-open-ingress",
+        "message": sprintf("Security group '%s' exposes rule '%s' to 0.0.0.0/0", [sg.name, rule.name])
+    }
+}
+
+# Kubernetes/Helm compliance: every pod must run as non-root.
+kubernetes_runs_as_root(artifact) = violation {
+    pod := artifact.content.pods[_]
+    not pod_runs_as_non_root(pod)
+    violation := {
+        "artifact": artifact.name,
+        "type": artifact.type,
+        "rule": "pods-must-run-as-non-root",
+        "message": sprintf("Pod '%s' is missing runAsNonRoot security context", [pod.name])
+    }
+}
+
+pod_runs_as_non_root(pod) {
+    security := pod.securityContext
+    security.runAsNonRoot == true
+}
+
+pod_runs_as_non_root(pod) {
+    container := pod.containers[_]
+    security := container.securityContext
+    security.runAsNonRoot == true
+}
+
+# Container image compliance: images must be cosign verified.
+image_not_cosign_signed(artifact) = violation {
+    not artifact.content.cosign_verified
+    violation := {
+        "artifact": artifact.name,
+        "type": "container_image",
+        "rule": "image-must-be-cosign-signed",
+        "message": sprintf("Container image '%s' is not cosign signed", [artifact.content.image])
+    }
+}
+
+allow {
+    count(violations) == 0
+}

--- a/policies/base/log_security.rego
+++ b/policies/base/log_security.rego
@@ -1,0 +1,116 @@
+package logsecurity
+
+# Patterns that represent verbose debug logging for various languages.
+debug_patterns = {
+    "javascript": "console.log",
+    "node.js": "console.log",
+    "python": "print",
+    "java": "system.out.println",
+    "c#": "console.writeline",
+    "go": "fmt.println"
+}
+
+# Keywords that usually represent protected health information (PHI) fields.
+phi_field_keywords := {"patient", "ssn", "mrn", "dob", "diagnosis", "medical", "treatment", "plan"}
+
+# Regular expressions that match PHI-like values that must never appear in logs.
+phi_patterns = [
+    {
+        "name": "us-ssn",
+        "pattern": "(?i)\\b(?!000|666)[0-8][0-9]{2}[- ]?(?!00)[0-9]{2}[- ]?(?!0000)[0-9]{4}\\b",
+        "message": "Log entry appears to contain a US social security number"
+    },
+    {
+        "name": "mrn",
+        "pattern": "(?i)mrn[:= ]?[0-9]{6,10}",
+        "message": "Log entry appears to contain a medical record number"
+    },
+    {
+        "name": "hipaa-email",
+        "pattern": "(?i)[a-z0-9._%+-]+@(?:hospital|clinic|healthcare)\\.[a-z]{2,}",
+        "message": "Log entry exposes an email address that looks like PHI"
+    }
+]
+
+# Rule: Deny if debug logging pattern is detected for the language of the log entry.
+deny[reason] {
+    log := input.log
+    log.message
+    lang := lower(log.language)
+    msg := lower(log.message)
+    pattern := debug_patterns[lang]
+    contains(msg, pattern)
+    reason := sprintf("Blocked debug log for language '%s' due to pattern '%s'", [log.language, pattern])
+}
+
+# Rule: Deny when a field name hints that PHI data is present in the payload.
+deny[reason] {
+    source := log_sources[_]
+    fields := source.fields
+    fields[key]
+    key_lower := lower(key)
+    some keyword
+    keyword := phi_field_keywords[_]
+    contains(key_lower, keyword)
+    reason := sprintf("%s field '%s' is considered PHI and must be redacted", [source.name, key])
+}
+
+# Rule: Deny when the message content matches well known PHI patterns (SSN, MRN, etc.).
+deny[reason] {
+    source := message_sources[_]
+    pattern := phi_patterns[_]
+    re_match(pattern.pattern, source.message)
+    reason := sprintf("%s: %s", [source.name, pattern.message])
+}
+
+log_sources[s] {
+    log := input.log
+    log.fields
+    s := {"name": "Log", "fields": log.fields}
+}
+
+log_sources[s] {
+    response := input.response
+    response.fields
+    s := {"name": "Response", "fields": response.fields}
+}
+
+log_sources[s] {
+    response := input.response
+    body := response.body
+    is_object(body)
+    s := {"name": "Response body", "fields": body}
+}
+
+message_sources[s] {
+    log := input.log
+    msg := log.message
+    is_string(msg)
+    s := {"name": "Log entry", "message": msg}
+}
+
+message_sources[s] {
+    log := input.log
+    msg := log.message
+    not is_string(msg)
+    s := {"name": "Log entry", "message": json.marshal(msg)}
+}
+
+message_sources[s] {
+    response := input.response
+    body := response.body
+    is_string(body)
+    s := {"name": "Response body", "message": body}
+}
+
+message_sources[s] {
+    response := input.response
+    body := response.body
+    not is_string(body)
+    s := {"name": "Response body", "message": json.marshal(body)}
+}
+
+# Default allow is true when the deny set is empty.
+allow {
+    count(deny) == 0
+}

--- a/policy_feed/cms_fda_guidance.rego
+++ b/policy_feed/cms_fda_guidance.rego
@@ -1,0 +1,19 @@
+package gatekeeper
+
+violations[v] {
+    artifact := input.artifacts[_]
+    required := artifact.metadata.cms_guidance_required
+    required == true
+    not has_guidance_version(artifact)
+    v := {
+        "artifact": artifact.name,
+        "type": artifact.type,
+        "rule": "cms-guidance-version-required",
+        "message": sprintf("Artifact '%s' requires CMS/FDA guidance annotation", [artifact.name])
+    }
+}
+
+has_guidance_version(artifact) {
+    annotations := artifact.metadata.annotations
+    annotations.cms_guidance_version != ""
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=2.3.3
+requests>=2.31.0

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -1,0 +1,103 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide light-weight stubs for third-party dependencies that are not
+# available in the execution environment during tests.
+flask_stub = types.ModuleType("flask")
+flask_stub.Flask = lambda name: mock.Mock(name="FlaskApp")
+flask_stub.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+flask_stub.request = mock.Mock(name="request")
+sys.modules.setdefault("flask", flask_stub)
+
+requests_stub = types.ModuleType("requests")
+
+
+class _StubSession:
+    def __init__(self):
+        self.put = mock.Mock(name="requests.put")
+        self.delete = mock.Mock(name="requests.delete")
+
+
+class RequestException(Exception):
+    pass
+
+
+requests_stub.Session = _StubSession
+requests_stub.RequestException = RequestException
+requests_stub.post = mock.Mock(
+    name="requests.post",
+    return_value=mock.Mock(
+        status_code=200,
+        raise_for_status=mock.Mock(),
+        json=lambda: {},
+    ),
+)
+sys.modules.setdefault("requests", requests_stub)
+
+# Ensure the global policy manager does not auto start when importing the app module in tests.
+os.environ.setdefault("AUTO_START_POLICY_MANAGER", "false")
+
+from app import PolicyManager, _extract_log_payload  # noqa: E402
+
+
+class PolicyManagerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        base_dir = Path(self._tmp.name) / "base"
+        dynamic_dir = Path(self._tmp.name) / "dynamic"
+        base_dir.mkdir()
+        dynamic_dir.mkdir()
+
+        (base_dir / "policy.rego").write_text("package test\nallow = true\n")
+
+        self.manager = PolicyManager(
+            opa_url="http://localhost:8181",
+            base_dir=base_dir,
+            dynamic_dir=dynamic_dir,
+            poll_interval=0,
+        )
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    @staticmethod
+    def _mock_response(status_code=200):
+        response = mock.Mock()
+        response.status_code = status_code
+        response.raise_for_status = mock.Mock()
+        return response
+
+    def test_force_reload_publishes_base_policy(self) -> None:
+        with mock.patch.object(self.manager.session, "put", return_value=self._mock_response()):
+            self.manager.force_reload()
+
+        self.assertIn("base:policy", self.manager._loaded)
+        self.assertEqual(self.manager.status["policy_count"], 1)
+        self.assertEqual(self.manager.status["dynamic_policy_count"], 0)
+
+    def test_dynamic_policy_sync_detects_new_files(self) -> None:
+        dynamic_policy_path = Path(self.manager.dynamic_dir) / "cms.rego"
+        dynamic_policy_path.write_text("package gatekeeper\nallow = true\n")
+
+        with mock.patch.object(self.manager.session, "put", return_value=self._mock_response()):
+            self.manager._sync_directory(self.manager.dynamic_dir, prefix="dynamic")
+
+        self.assertIn("dynamic:cms", self.manager._loaded)
+        self.assertEqual(self.manager.status.get("last_error"), None)
+
+    def test_extract_log_payload_helper(self) -> None:
+        wrapped = {"log": {"message": "hello"}}
+        plain = {"message": "hello"}
+        self.assertEqual(_extract_log_payload(wrapped), wrapped["log"])
+        self.assertEqual(_extract_log_payload(plain), plain)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Node package manifest so JavaScript tooling can integrate with the governance project
- ignore Node artifacts such as node_modules and npm debug logs

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8fd11a7848328ab3495dba4eeb175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added automated policy management with background syncing.
  - Introduced endpoints for log checks, gatekeeper validation, policy reload, and policy status.
  - Added base policies for PHI-redaction in logs and artifact compliance (Terraform, Kubernetes/Helm, container images).
  - Added dynamic policy feed support.

- Chores
  - Upgraded runtime to Python 3.11 and switched to requirements-based installs.
  - Introduced package and dependency metadata; added .gitignore.
  - Docker Compose revamped: new governance API service; OPA runs with debug logging.

- Documentation
  - Updated project title to “OPA Governance Toolkit”.

- Tests
  - Added unit tests for policy management.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the governance toolkit by introducing a new OPA policy management system and updating core components. It includes changes to the Dockerfile and dependencies, adds new rego policy files for compliance and security, and implements new endpoints for policy queries and dynamic reloads to improve HIPAA compliance and auditing.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
-->
</div>