### PR TITLE
Implement attribute change engine for directory services

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,11 +245,7 @@ def policies_status():
 
 
 if __name__ == "__main__":
-<<<<<<< HEAD
     try:
         app.run(host="0.0.0.0", port=5000)
     finally:
         policy_manager.stop()
-=======
-    app.run(port=5001)
->>>>>>> a6bf77b (Your descriptive commit message)

--- a/attribute_engine.py
+++ b/attribute_engine.py
@@ -1,0 +1,197 @@
+"""Attribute change engine for synchronising user attributes across directory services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Protocol, Sequence, Tuple
+
+
+class AttributeChangeError(RuntimeError):
+    """Base exception for attribute change operations."""
+
+    def __init__(self, message: str, *, service: Optional[str] = None, cause: Optional[BaseException] = None) -> None:
+        super().__init__(message)
+        self.service = service
+        self.__cause__ = cause
+
+
+class UnknownDirectoryServiceError(AttributeChangeError):
+    """Raised when an attribute change targets a non-existent directory service."""
+
+    def __init__(self, service: str) -> None:
+        super().__init__(f"Unknown directory service: {service}", service=service)
+
+
+class DirectoryService(Protocol):
+    """Protocol describing the interface required by the change engine."""
+
+    name: str
+
+    def update_attribute(self, user_id: str, attribute: str, value: Any) -> None:
+        """Persist an attribute change for ``user_id`` within the directory."""
+
+
+UpdateHandler = Callable[[str, str, Any], None]
+
+
+@dataclass(frozen=True)
+class AttributeChangeRequest:
+    """Represents a single attribute change that should be propagated."""
+
+    user_id: str
+    attribute: str
+    value: Any
+    services: Optional[Tuple[str, ...]] = None
+
+    def __post_init__(self) -> None:
+        if not self.user_id:
+            raise ValueError("user_id must be provided")
+        if not self.attribute:
+            raise ValueError("attribute must be provided")
+
+        if self.services is not None:
+            services: Sequence[str] = self.services
+            normalized: List[str] = []
+            for service in services:
+                if not isinstance(service, str) or not service.strip():
+                    raise ValueError("service names must be non-empty strings")
+                normalized.append(service.strip())
+            object.__setattr__(self, "services", tuple(normalized))
+
+
+@dataclass
+class AttributeChangeResult:
+    """Outcome of applying an :class:`AttributeChangeRequest`."""
+
+    request: AttributeChangeRequest
+    successful: List[str] = field(default_factory=list)
+    failures: Dict[str, AttributeChangeError] = field(default_factory=dict)
+
+    @property
+    def success(self) -> bool:
+        return not self.failures
+
+    def raise_if_failed(self) -> None:
+        if self.failures:
+            messages = ", ".join(f"{service}: {error}" for service, error in self.failures.items())
+            raise AttributeChangeError(
+                f"One or more directory updates failed: {messages}",
+                cause=next(iter(self.failures.values())),
+            )
+
+
+class AttributeChangeEngine:
+    """Coordinate attribute changes across multiple directory services."""
+
+    def __init__(self) -> None:
+        self._services: Dict[str, UpdateHandler] = {}
+
+    # ------------------------------------------------------------------
+    # Service registration helpers
+    # ------------------------------------------------------------------
+    def register_service(
+        self,
+        service: DirectoryService | UpdateHandler,
+        *,
+        name: Optional[str] = None,
+        replace: bool = False,
+    ) -> None:
+        """Register a directory service implementation with the engine.
+
+        Args:
+            service: Either an object implementing :class:`DirectoryService`
+                or a callable with the signature ``(user_id, attribute, value)``.
+            name: Optional explicit service name. If omitted and ``service`` is an
+                object, the ``name`` attribute will be used.
+            replace: If ``True`` existing registrations with the same name will be
+                replaced. The default is to raise a :class:`ValueError`.
+        """
+
+        resolved_name = self._resolve_service_name(service, name)
+        if resolved_name in self._services and not replace:
+            raise ValueError(f"Service '{resolved_name}' is already registered")
+
+        handler = self._coerce_handler(service)
+        self._services[resolved_name] = handler
+
+    def unregister_service(self, name: str) -> None:
+        """Remove a previously registered directory service."""
+
+        self._services.pop(name, None)
+
+    def services(self) -> Tuple[str, ...]:
+        """Return a tuple of registered service names."""
+
+        return tuple(self._services.keys())
+
+    # ------------------------------------------------------------------
+    # Attribute propagation
+    # ------------------------------------------------------------------
+    def apply_change(self, change: AttributeChangeRequest) -> AttributeChangeResult:
+        """Apply a single attribute change to all targeted services."""
+
+        result = AttributeChangeResult(request=change)
+        target_services = change.services or self.services()
+
+        for service_name in target_services:
+            handler = self._services.get(service_name)
+            if handler is None:
+                result.failures[service_name] = UnknownDirectoryServiceError(service_name)
+                continue
+
+            try:
+                handler(change.user_id, change.attribute, change.value)
+            except AttributeChangeError as error:
+                result.failures[service_name] = AttributeChangeError(
+                    str(error), service=service_name, cause=error
+                )
+            except Exception as error:  # pragma: no cover - defensive
+                result.failures[service_name] = AttributeChangeError(
+                    f"Unexpected error: {error}", service=service_name, cause=error
+                )
+            else:
+                result.successful.append(service_name)
+
+        return result
+
+    def apply_changes(self, changes: Iterable[AttributeChangeRequest]) -> List[AttributeChangeResult]:
+        """Apply multiple changes and return their results."""
+
+        return [self.apply_change(change) for change in changes]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_service_name(
+        service: DirectoryService | UpdateHandler, name: Optional[str]
+    ) -> str:
+        if name is not None:
+            resolved = name.strip()
+            if not resolved:
+                raise ValueError("Service name must not be empty")
+            return resolved
+
+        if callable(service) and not hasattr(service, "name"):
+            raise ValueError("A name must be provided when registering a callable")
+
+        resolved = getattr(service, "name", None)
+        if not isinstance(resolved, str) or not resolved.strip():
+            raise ValueError("Service object must define a non-empty 'name' attribute")
+        return resolved.strip()
+
+    @staticmethod
+    def _coerce_handler(service: DirectoryService | UpdateHandler) -> UpdateHandler:
+        if callable(service) and not hasattr(service, "update_attribute"):
+            return service  # type: ignore[return-value]
+        return getattr(service, "update_attribute")
+
+
+__all__ = [
+    "AttributeChangeEngine",
+    "AttributeChangeError",
+    "AttributeChangeRequest",
+    "AttributeChangeResult",
+    "DirectoryService",
+    "UnknownDirectoryServiceError",
+]

--- a/tests/test_attribute_engine.py
+++ b/tests/test_attribute_engine.py
@@ -1,0 +1,104 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from attribute_engine import (
+    AttributeChangeEngine,
+    AttributeChangeError,
+    AttributeChangeRequest,
+    UnknownDirectoryServiceError,
+)
+
+
+class _RecordingService:
+    def __init__(self, name, records):
+        self.name = name
+        self._records = records
+
+    def update_attribute(self, user_id, attribute, value):
+        self._records.append((self.name, user_id, attribute, value))
+
+
+class AttributeChangeEngineTests(unittest.TestCase):
+    def setUp(self):
+        self.records = []
+        self.engine = AttributeChangeEngine()
+        self.engine.register_service(_RecordingService("ldap", self.records))
+        self.engine.register_service(_RecordingService("okta", self.records))
+
+    def test_apply_change_updates_all_services_by_default(self):
+        request = AttributeChangeRequest("user-1", "email", "user@example.com")
+        result = self.engine.apply_change(request)
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(self.records), 2)
+        self.assertEqual(
+            self.records,
+            [
+                ("ldap", "user-1", "email", "user@example.com"),
+                ("okta", "user-1", "email", "user@example.com"),
+            ],
+        )
+
+    def test_apply_change_with_specific_services(self):
+        request = AttributeChangeRequest("user-2", "department", "Engineering", services=("okta",))
+        result = self.engine.apply_change(request)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.successful, ["okta"])
+        self.assertEqual(self.records, [("okta", "user-2", "department", "Engineering")])
+
+    def test_unknown_service_reports_failure(self):
+        request = AttributeChangeRequest("user-3", "title", "Manager", services=("unknown",))
+        result = self.engine.apply_change(request)
+
+        self.assertFalse(result.success)
+        self.assertIsInstance(result.failures["unknown"], UnknownDirectoryServiceError)
+
+    def test_apply_changes_batches_multiple_requests(self):
+        requests = [
+            AttributeChangeRequest("user-a", "email", "a@example.com"),
+            AttributeChangeRequest("user-b", "email", "b@example.com", services=("ldap",)),
+        ]
+
+        results = self.engine.apply_changes(requests)
+
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(result.success for result in results))
+        self.assertEqual(len(self.records), 3)
+
+    def test_registering_duplicate_service_requires_replace(self):
+        with self.assertRaises(ValueError):
+            self.engine.register_service(_RecordingService("ldap", self.records))
+
+        # ensure replace=True overwrites
+        self.engine.register_service(_RecordingService("ldap", self.records), replace=True)
+        request = AttributeChangeRequest("user-c", "email", "c@example.com", services=("ldap",))
+        result = self.engine.apply_change(request)
+        self.assertTrue(result.success)
+
+    def test_callable_registration_requires_name(self):
+        updates = []
+
+        def handler(user_id, attribute, value):
+            updates.append((user_id, attribute, value))
+
+        self.engine.register_service(handler, name="custom")
+        request = AttributeChangeRequest("user-d", "phone", "+1")
+        result = self.engine.apply_change(request)
+
+        self.assertTrue(result.success)
+        self.assertIn(("user-d", "phone", "+1"), updates)
+
+    def test_raise_if_failed(self):
+        request = AttributeChangeRequest("user-e", "role", "admin", services=("missing",))
+        result = self.engine.apply_change(request)
+
+        with self.assertRaises(AttributeChangeError):
+            result.raise_if_failed()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable attribute change engine for coordinating updates across directory services
- cover the new engine with unit tests and fix the Flask entrypoint merge conflict

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e226d0f4088328bf00d6677f7742be 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new attribute change engine to enhance user attribute management across directory services. It resolves a merge conflict in the Flask entry point and includes unit tests to validate the new functionality, ensuring reliable integration.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an Attribute Change Engine to synchronize user attributes across multiple directory services, with per-service success/failure reporting and batch processing.
- Refactor
  - Updated the default server configuration to run on port 5001 with simplified startup behavior.
- Tests
  - Added comprehensive tests for service registration, scoped updates, error handling, batch operations, and result aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->